### PR TITLE
Add convenience functions for loading and dumping manifests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,8 @@ jobs:
           -r requirements.txt
           pytest pytest-cov
           requests
-          tomli
+          ${{ matrix.python == '3.9' && 'tomlkit' || 'tomli' }}
+          ${{ matrix.python == '3.10' && 'tomli-w' || 'tomlkit' }}
 
       - name: Install project
         run: pip install . -v --no-deps
@@ -142,6 +143,14 @@ jobs:
             popd
           done
 
+      - name: Publish to Test PyPI
+        if: ${{ github.event_name == 'release' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
       - name: Upload assets
         uses: svenstaro/upload-release-action@v2
         if: ${{ github.event_name == 'release' }}
@@ -151,3 +160,10 @@ jobs:
           file_glob: true
           tag: ${{ github.ref }}
           overwrite: true
+
+      - name: Publish to PyPI
+        if: ${{ github.event_name == 'release' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,30 @@ in Python
    >>> package.version
    '0.2.0'
 
+Alternatively, you can use the ``load_manifest`` function to read a package manifest
+
+.. code:: python
+
+   >>> from pathlib import Path
+   >>> from fpm.metadata import load_manifest
+   >>> package = load_manifest(Path("fpm.toml"))
+   >>> package.name
+   'fpm'
+   >>> package.version
+   '0.2.0'
+
+Finally, you can dump a package manifest to a TOML string using the ``dump_manifest`` function
+
+.. code:: python
+
+   >>> from pathlib import Path
+   >>> from fpm.metadata import dump_manifest, load_manifest
+   >>> package = load_manifest(Path("fpm.toml"))
+   >>> print(dump_manifest(package))
+   name = "fpm"
+   version = "0.2.0"
+   ...
+
 
 Development
 -----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fpm-metadata
-version = 0.2.0
+version = 0.2.1
 description = Python model for the Fortran package manifest
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/src/fpm/metadata/__init__.py
+++ b/src/fpm/metadata/__init__.py
@@ -16,4 +16,115 @@
 Python model for Fortran package manifests
 """
 
+from pathlib import Path
+from typing import Optional, Union
+
 from .models import Manifest
+
+
+for impl in ["tomllib", "tomli", "tomlkit", "pytomlpp"]:
+    try:
+        toml = __import__(impl)
+        break
+    except ModuleNotFoundError:
+        toml = None
+
+
+for impl in ["tomli_w", "tomlkit", "pytomlpp"]:
+    try:
+        tomlw = __import__(impl)
+        break
+    except ModuleNotFoundError:
+        tomlw = None
+
+
+def load_manifest(inp: Union[str, Path]) -> Manifest:
+    """
+    Load a manifest from a file or string
+
+    Parameters
+    ----------
+    inp : str or Path
+        Path to a manifest file or a string containing a manifest
+
+    Returns
+    -------
+    Manifest
+        A manifest object
+
+    Examples
+    --------
+    >>> manifest = load_manifest("name = 'hello'")
+    >>> manifest.name
+    'hello'
+    """
+
+    if toml is None:
+        raise ModuleNotFoundError("No TOML library available")
+
+    if isinstance(inp, Path):
+        with open(inp, "rb") as fd:
+            data = toml.load(fd)
+    else:
+        data = toml.loads(inp)
+
+    return Manifest(**data)
+
+
+def dump_manifest(manifest: Manifest, out: Optional[Path] = None) -> Optional[str]:
+    """
+    Write a manifest to a file
+
+    Parameters
+    ----------
+    manifest : Manifest
+        A manifest object
+    out : Path, optional
+        Path to a file to write the manifest to, by default None
+
+    Returns
+    -------
+    str or None
+        If out is None, the manifest is returned as a string
+
+    Examples
+    --------
+    >>> manifest = Manifest(name="hello")
+    >>> print(dump_manifest(manifest))
+    name = "hello"
+    version = "0"
+    <BLANKLINE>
+    [build]
+    auto_tests = true
+    auto_executables = true
+    auto_examples = true
+    <BLANKLINE>
+    [install]
+    library = false
+    <BLANKLINE>
+    [library]
+    source_dir = "src"
+    include_dir = "include"
+    <BLANKLINE>
+    """
+
+    if tomlw is None:
+        raise ModuleNotFoundError("No TOML library available")
+
+    def empty(data):
+        return data is None or (isinstance(data, (list, dict)) and not data)
+
+    def prune(data):
+        if isinstance(data, dict):
+            return {k: prune(v) for k, v in data.items() if not empty(v)}
+        if isinstance(data, list):
+            return [prune(v) for v in data if not empty(v)]
+        return data
+
+    data = prune(manifest.dict())
+
+    if out is None:
+        return tomlw.dumps(data)
+
+    with open(out, "wb" if tomlw.__name__ == "tomli_w" else "w") as fd:
+        tomlw.dump(prune(data), fd)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,9 +1,26 @@
 import pytest
 import requests
-import tomli as toml
+import tempfile
 from pathlib import Path
 
-from fpm.metadata import Manifest
+import fpm.metadata
+from fpm.metadata import Manifest, load_manifest, dump_manifest
+
+toml = []
+for impl in ["tomllib", "tomli", "tomlkit", "pytomlpp"]:
+    try:
+        toml.append(__import__(impl))
+    except ModuleNotFoundError:
+        pass
+
+
+tomlw = []
+for impl in ["tomli_w", "tomlkit", "pytomlpp"]:
+    try:
+        tomlw.append(__import__(impl))
+    except ModuleNotFoundError:
+        pass
+
 
 
 root = Path(__file__).parent
@@ -17,13 +34,64 @@ repos = [
 ]
 
 
+@pytest.mark.parametrize("impl", toml)
+def test_load_manifest(impl):
+    _toml = fpm.metadata.toml
+    fpm.metadata.toml = impl
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file = Path(tmpdir) / "fpm.toml"
+        with open(file, "w") as fd:
+            fd.write("name = 'hello'\nkeywords = ['foo', 'bar']")
+        manifest = load_manifest(file)
+        assert manifest.name == "hello"
+        assert manifest.keywords == ["foo", "bar"]
+    fpm.metadata.toml = _toml
+
+
+def test_load_manifest_no_impl():
+    _toml = fpm.metadata.toml
+    fpm.metadata.toml = None
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file = Path(tmpdir) / "fpm.toml"
+        with open(file, "w") as fd:
+            fd.write("name = 'hello'")
+        with pytest.raises(ModuleNotFoundError):
+            load_manifest(file)
+    fpm.metadata.toml = _toml
+
+
+@pytest.mark.parametrize("impl", tomlw)
+def test_dump_manifest(impl):
+    _toml = fpm.metadata.tomlw
+    fpm.metadata.tomlw = impl
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file = Path(tmpdir) / "fpm.toml"
+        dump_manifest(Manifest(name="hello", keywords=["foo", "bar"]), file)
+        assert file.exists()
+        manifest = load_manifest(file)
+        assert manifest.name == "hello"
+        assert manifest.keywords == ["foo", "bar"]
+    fpm.metadata.tomlw = _toml
+
+
+def test_dump_manifest_no_impl():
+    _toml = fpm.metadata.tomlw
+    fpm.metadata.tomlw = None
+    manifest = Manifest(name="hello")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file = Path(tmpdir) / "fpm.toml"
+        with pytest.raises(ModuleNotFoundError):
+            dump_manifest(manifest, file)
+    fpm.metadata.tomlw = _toml
+
+
 @pytest.mark.parametrize("repo", repos)
 def test_github(repo):
     repo = repo.replace("https://github.com/", "")
     response = requests.get(f"https://raw.githubusercontent.com/{repo}/HEAD/fpm.toml")
     if response.status_code == 200:
         try:
-            manifest = Manifest(**toml.loads(response.text))
+            load_manifest(response.text)
         except Exception as e:
             print(response.text)
             print(e)


### PR DESCRIPTION
Doesn't require user to make choice on TOML library, `fpm.metadata` will make an appropriate choice from the available implementations.